### PR TITLE
Change image path return types

### DIFF
--- a/src/Traits/HasMedia.php
+++ b/src/Traits/HasMedia.php
@@ -2,6 +2,8 @@
 
 namespace DrewRoberts\Blog\Traits;
 
+use Illuminate\Contracts\Routing\UrlGenerator;
+
 trait HasMedia
 {
     public function image()

--- a/src/Traits/HasMedia.php
+++ b/src/Traits/HasMedia.php
@@ -2,6 +2,8 @@
 
 namespace DrewRoberts\Blog\Traits;
 
+use Illuminate\Contracts\Routing\UrlGenerator;
+
 trait HasMedia
 {
     public function image()
@@ -29,7 +31,7 @@ trait HasMedia
         $cloudName = config('filesystem.disks.cloudinary.cloud_name');
 
         return $this->image === null ?
-            url('img/ogimage.jpg') :
+            (string) url('img/ogimage.jpg') :
             "https://res.cloudinary.com/{$cloudName}/t_cover/{$this->image->filename}";
     }
 
@@ -43,7 +45,7 @@ trait HasMedia
         $cloudName = config('filesystem.disks.cloudinary.cloud_name');
 
         return $this->image === null ?
-            url('img/ogimage.jpg') :
+            (string) url('img/ogimage.jpg') :
             "https://res.cloudinary.com/{$cloudName}/t_coverplaceholder/{$this->image->filename}";
     }
 }

--- a/src/Traits/HasMedia.php
+++ b/src/Traits/HasMedia.php
@@ -24,28 +24,28 @@ trait HasMedia
     /**
      * Get a string path for the page image.
      *
-     * @return string
+     * @return UrlGenerator|string
      */
     public function getImagePathAttribute()
     {
         $cloudName = config('filesystem.disks.cloudinary.cloud_name');
 
-        return $this->image === null ?
-            (string) url('img/ogimage.jpg') :
-            "https://res.cloudinary.com/{$cloudName}/t_cover/{$this->image->filename}";
+        return $this->image === null
+            ? url('img/ogimage.jpg')
+            : "https://res.cloudinary.com/{$cloudName}/t_cover/{$this->image->filename}";
     }
 
     /**
      * Get a string path for the page image's placeholder.
      *
-     * @return string
+     * @return UrlGenerator|string
      */
     public function getPlaceholderPathAttribute()
     {
         $cloudName = config('filesystem.disks.cloudinary.cloud_name');
 
-        return $this->image === null ?
-            (string) url('img/ogimage.jpg') :
-            "https://res.cloudinary.com/{$cloudName}/t_coverplaceholder/{$this->image->filename}";
+        return $this->image === null
+            ? url('img/ogimage.jpg')
+            : "https://res.cloudinary.com/{$cloudName}/t_coverplaceholder/{$this->image->filename}";
     }
 }


### PR DESCRIPTION
**BUGFIX***
- Psalm was throwing an error because of the return type that could be `UrlGenerator` if `url(path: string)` path was empty 