### PR TITLE
Update BlogController and PageController logic for #79 and #80

### DIFF
--- a/resources/views/page/amp.blade.php
+++ b/resources/views/page/amp.blade.php
@@ -1,6 +1,11 @@
 @extends('support::amp')
 
 @section('content')
+    {{-- DO NOT REMOVE - page identity tag --}}
+    <!-- P:{{ $page->id }} C:{{ $child_page->id ?? '0' }} GC:{{ $grand_child_page->id ?? '0' }} -->
+
+
+    {{-- Place holder content - safe to replace --}}
     <ul>
         <li>Page: {{ $page->name }}</li>
         <li>Child: {{ $child_page->name ?? 'NONE' }}</li>

--- a/resources/views/page/base.blade.php
+++ b/resources/views/page/base.blade.php
@@ -1,6 +1,11 @@
 @extends('support::base')
 
 @section('content')
+    {{-- DO NOT REMOVE - page identity tag --}}
+    <!-- P:{{ $page->id }} C:{{ $child_page->id ?? '0' }} GC:{{ $grand_child_page->id ?? '0' }} -->
+
+
+    {{-- Place holder content - safe to replace --}}
     <ul>
         <li>Page: {{ $page->name }}</li>
         <li>Child: {{ $child_page->name ?? 'NONE' }}</li>

--- a/resources/views/post/amp.blade.php
+++ b/resources/views/post/amp.blade.php
@@ -1,6 +1,10 @@
 @extends('support::amp')
 
 @section('content')
+    {{-- DO NOT REMOVE - identity tag --}}
+    <!-- T:{{ $topic->id ?? '0' }} S:{{ $series->id ?? '0' }} P:{{ $post->id }} -->
+
+    {{-- Place holder content - safe to replace --}}
     <ul>
         <li>Topic: {{ $topic->name ?? 'NONE' }}</li>
         <li>Series: {{ $series->name ?? 'NONE' }}</li>

--- a/resources/views/post/base.blade.php
+++ b/resources/views/post/base.blade.php
@@ -1,6 +1,10 @@
 @extends('support::base')
 
 @section('content')
+    {{-- DO NOT REMOVE - identity tag --}}
+    <!-- T:{{ $topic->id ?? '0' }} S:{{ $series->id ?? '0' }} P:{{ $post->id }} -->
+
+    {{-- Place holder content - safe to replace --}}
     <ul>
         <li>Topic: {{ $topic->name ?? 'NONE' }}</li>
         <li>Series: {{ $series->name ?? 'NONE' }}</li>

--- a/resources/views/series/amp.blade.php
+++ b/resources/views/series/amp.blade.php
@@ -1,6 +1,10 @@
 @extends('support::amp')
 
 @section('content')
+    {{-- DO NOT REMOVE - identity tag --}}
+    <!-- T:{{ $topic->id }} S:{{ $series->id }} -->
+
+    {{-- Place holder content - safe to replace --}}
     <ul>
         <li>Topic: {{ $topic->name }}</li>
         <li>Series: {{ $series->name }}</li>

--- a/resources/views/series/base.blade.php
+++ b/resources/views/series/base.blade.php
@@ -1,6 +1,10 @@
 @extends('support::base')
 
 @section('content')
+    {{-- DO NOT REMOVE - identity tag --}}
+    <!-- T:{{ $topic->id }} S:{{ $series->id }} -->
+
+    {{-- Place holder content - safe to replace --}}
     <ul>
         <li>Topic: {{ $topic->name }}</li>
         <li>Series: {{ $series->name }}</li>

--- a/resources/views/topic/amp.blade.php
+++ b/resources/views/topic/amp.blade.php
@@ -1,6 +1,10 @@
 @extends('support::amp')
 
 @section('content')
+    {{-- DO NOT REMOVE - identity tag --}}
+    <!-- T:{{ $topic->id }} -->
+
+    {{-- Place holder content - safe to replace --}}
     <ul>
         <li>Topic: {{ $topic->name }}</li>
     </ul>

--- a/resources/views/topic/base.blade.php
+++ b/resources/views/topic/base.blade.php
@@ -1,6 +1,10 @@
 @extends('support::base')
 
 @section('content')
+    {{-- DO NOT REMOVE - identity tag --}}
+    <!-- T:{{ $topic->id }} -->
+
+    {{-- Place holder content - safe to replace --}}
     <ul>
         <li>Topic: {{ $topic->name }}</li>
     </ul>

--- a/src/Http/Controllers/BlogController.php
+++ b/src/Http/Controllers/BlogController.php
@@ -60,8 +60,6 @@ class BlogController extends BaseController
     private function handlePageRoute(Request $request, Page $page, ?string $slug2 = null, ?string $slug3 = null)
     {
         if (empty($slug2)) {
-            abort_unless($page->is_leaf, 404);
-
             return app(PageController::class)($request, $page);
         }
 
@@ -71,8 +69,6 @@ class BlogController extends BaseController
             ->where('slug', '=', $slug2)
             ->first()) {
             if (empty($slug3)) {
-                abort_unless($childPage->is_leaf, 404);
-
                 return app(PageController::class)($request, $page, $childPage);
             }
 
@@ -85,7 +81,7 @@ class BlogController extends BaseController
             }
         }
 
-        // Valid topic, but invalid nesting of series or post slugs
+        // Valid root page, but invalid nesting of pages
         abort(404);
     }
 }

--- a/src/Http/Controllers/PageController.php
+++ b/src/Http/Controllers/PageController.php
@@ -13,9 +13,14 @@ class PageController extends BaseController
 {
     public function __invoke(Request $request, Page $page, ?Page $childPage = null, Page $grandChildPage = null)
     {
-        // If location based child is only child of parent, redirect to parent alone!!
-        if ($childPage && $childPage->location_based && $page->children->count() === 1) {
-            return redirect(url($page->path));
+        // If location based grand child is only child, redirect!!
+        if ($grandChildPage && $grandChildPage->location_based && $grandChildPage->is_only_child) {
+            return redirect(url($grandChildPage->path));
+        }
+
+        // If location based child is only child, redirect!!!
+        if ($childPage && $childPage->location_based && $childPage->is_only_child) {
+            return redirect(url($childPage->path));
         }
 
         $leafPage = $grandChildPage ?: ($childPage ?: $page);

--- a/src/Http/Controllers/PageController.php
+++ b/src/Http/Controllers/PageController.php
@@ -14,13 +14,20 @@ class PageController extends BaseController
     public function __invoke(Request $request, Page $page, ?Page $childPage = null, Page $grandChildPage = null)
     {
         // If location based grand child is only child, redirect!!
-        if ($grandChildPage && $grandChildPage->location_based && $grandChildPage->is_only_child) {
-            return redirect(url($grandChildPage->path));
-        }
-
-        // If location based child is only child, redirect!!!
-        if ($childPage && $childPage->location_based && $childPage->is_only_child) {
-            return redirect(url($childPage->path));
+        if ($grandChildPage) {
+            if ($grandChildPage->location_based && $grandChildPage->is_only_child) {
+                return redirect(url($grandChildPage->path));
+            }
+        } elseif ($childPage) {
+            // If location based child is only child, redirect!!!
+            if ($childPage->location_based && $childPage->is_only_child) {
+                return redirect(url($childPage->path));
+            }
+        } else {
+            // If there is only  location based root page, redirect home!
+            if ($page->is_only_root_location) {
+                return redirect(url($page->path));
+            }
         }
 
         $leafPage = $grandChildPage ?: ($childPage ?: $page);

--- a/src/Http/Controllers/PageController.php
+++ b/src/Http/Controllers/PageController.php
@@ -13,6 +13,11 @@ class PageController extends BaseController
 {
     public function __invoke(Request $request, Page $page, ?Page $childPage = null, Page $grandChildPage = null)
     {
+        // If location based child is only child of parent, redirect to parent alone!!
+        if ($childPage && $childPage->location_based && $page->children->count() === 1) {
+            return redirect(url($page->path));
+        }
+
         $leafPage = $grandChildPage ?: ($childPage ?: $page);
         LayoutManager::setLayout($leafPage->layout);
 

--- a/src/Models/Page.php
+++ b/src/Models/Page.php
@@ -147,7 +147,7 @@ class Page extends BaseModel
         $parent = $this;
         while ($parent) {
             // Start accumulating slugs when not location based or not only child
-            if ($path || !$parent->location_based || !$parent->is_only_child) {
+            if ($path || ! $parent->location_based || ! $parent->is_only_child) {
                 $path[] = $parent->slug;
             }
             $parent = $parent->parent;

--- a/src/Models/Page.php
+++ b/src/Models/Page.php
@@ -30,6 +30,7 @@ use Tipoff\Support\Traits\HasUpdater;
  * @property bool is_leaf
  * @property bool is_root
  * @property bool is_only_child
+ * @property bool is_only_root_location
  * @property string|null path
  * @property int depth
  * @property string content
@@ -138,17 +139,27 @@ class Page extends BaseModel
 
     public function getPathAttribute(): ?string
     {
+        if ($this->is_only_root_location) {
+            return '/';
+        }
+
         $path = [];
         $parent = $this;
         while ($parent) {
-            // Start accumulating slugs when not only child
-            if ($path || !$parent->is_only_child) {
+            // Start accumulating slugs when not location based or not only child
+            if ($path || !$parent->location_based || !$parent->is_only_child) {
                 $path[] = $parent->slug;
             }
             $parent = $parent->parent;
         }
 
         return implode('/', array_reverse($path));
+    }
+
+    public function getIsOnlyRootLocationAttribute(): bool
+    {
+        return ($this->location_based && $this->is_root &&
+            static::query()->whereNull('parent_id')->where('location_based', true)->count() === 1);
     }
 
     public function getIsRootAttribute(): bool

--- a/src/Models/Page.php
+++ b/src/Models/Page.php
@@ -128,7 +128,7 @@ class Page extends BaseModel
     {
         return 'slug';
     }
-    
+
     public function layout()
     {
         return $this->belongsTo(app('layout'));
@@ -136,7 +136,7 @@ class Page extends BaseModel
 
     public function getPathAttribute(): ?string
     {
-        return $this->is_leaf ? '/' . implode('/', $this->getParentPath()) : null;
+        return implode('/', $this->getParentPath());
     }
 
     public function getIsRootAttribute(): bool
@@ -159,7 +159,7 @@ class Page extends BaseModel
         $path = [];
         $parent = $this;
         while ($parent) {
-            $path[] = $parent;
+            $path[] = $parent->slug;
             $parent = $parent->parent;
         }
 

--- a/tests/Unit/Http/Controllers/PageControllerTest.php
+++ b/tests/Unit/Http/Controllers/PageControllerTest.php
@@ -61,6 +61,37 @@ class PageControllerTest extends TestCase
     }
 
     /** @test */
+    public function location_based_single_grand_child_redirects_to_parent()
+    {
+        $this->logToStderr();
+        $page = Page::factory()->create([
+            'location_based' => true,
+        ]);
+
+        $child1 = Page::factory()->create([
+            'location_based' => true,
+        ])->setParent($page);
+
+        $grandChild = Page::factory()->create([
+            'location_based' => true,
+        ])->setParent($child1);
+
+        $this->get($this->webUrl("/{$page->slug}"))
+            ->assertOk()
+            ->assertSee("-- P:{$page->id} C:0 GC:0 --");
+
+        $this->get($this->webUrl("/{$page->slug}/{$child1->slug}/{$grandChild->slug}"))
+            ->assertRedirect("/{$page->slug}");
+
+        $child2 = Page::factory()->create([
+            'location_based' => true,
+        ])->setParent($page);
+
+        $this->get($this->webUrl("/{$page->slug}/{$child1->slug}/{$grandChild->slug}"))
+            ->assertRedirect("/{$page->slug}/{$child1->slug}");
+    }
+
+    /** @test */
     public function location_based_multi_child_does_not_redirect()
     {
         $this->logToStderr();

--- a/tests/Unit/Http/Controllers/PageControllerTest.php
+++ b/tests/Unit/Http/Controllers/PageControllerTest.php
@@ -43,7 +43,6 @@ class PageControllerTest extends TestCase
     /** @test */
     public function location_based_single_child_redirects_to_parent()
     {
-        $this->logToStderr();
         $page = Page::factory()->create([
             'location_based' => true,
         ]);
@@ -53,8 +52,11 @@ class PageControllerTest extends TestCase
         ])->setParent($page);
 
         $this->get($this->webUrl("/{$page->slug}"))
-            ->assertOk()
-            ->assertSee("-- P:{$page->id} C:0 GC:0 --");
+            ->assertRedirect('/');
+
+        Page::factory()->create([
+            'location_based' => true,
+        ]);
 
         $this->get($this->webUrl("/{$page->slug}/{$child->slug}"))
             ->assertRedirect("/{$page->slug}");
@@ -63,10 +65,9 @@ class PageControllerTest extends TestCase
     /** @test */
     public function location_based_single_grand_child_redirects_to_parent()
     {
-        $this->logToStderr();
-        $page = Page::factory()->create([
+        $page = Page::factory()->count(2)->create([
             'location_based' => true,
-        ]);
+        ])->first();
 
         $child1 = Page::factory()->create([
             'location_based' => true,
@@ -94,10 +95,9 @@ class PageControllerTest extends TestCase
     /** @test */
     public function location_based_multi_child_does_not_redirect()
     {
-        $this->logToStderr();
-        $page = Page::factory()->create([
+        $page = Page::factory()->count(2)->create([
             'location_based' => true,
-        ]);
+        ])->first();
 
         $child1 = Page::factory()->create([
             'location_based' => true,

--- a/tests/Unit/Http/Controllers/PostControllerTest.php
+++ b/tests/Unit/Http/Controllers/PostControllerTest.php
@@ -27,9 +27,7 @@ class PostControllerTest extends TestCase
 
         $this->get($this->webUrl("/{$topic->slug}/{$series->slug}/{$post->slug}"))
             ->assertOk()
-            ->assertSee("Topic: {$topic->name}")
-            ->assertSee("Series: {$series->name}")
-            ->assertSee("Post: {$post->name}");
+            ->assertSee("-- T:{$topic->id} S:{$topic->id} P:{$post->id} --");
     }
 
     /** @test */
@@ -42,9 +40,7 @@ class PostControllerTest extends TestCase
 
         $this->get($this->webUrl("/blog/{$post->slug}"))
             ->assertOk()
-            ->assertSee("Topic: NONE")
-            ->assertSee("Series: NONE")
-            ->assertSee("Post: {$post->name}");
+            ->assertSee("-- T:0 S:0 P:{$post->id} --");
     }
 
     /** @test */

--- a/tests/Unit/Http/Controllers/SeriesControllerTest.php
+++ b/tests/Unit/Http/Controllers/SeriesControllerTest.php
@@ -27,9 +27,7 @@ class SeriesControllerTest extends TestCase
 
         $this->get($this->webUrl("/{$topic->slug}/{$series->slug}"))
             ->assertOk()
-            ->assertSee("Topic: {$topic->name}")
-            ->assertSee("Series: {$series->name}")
-            ->assertDontSee("Post: {$post->name}");
+            ->assertSee("-- T:{$topic->id} S:{$topic->id} --");
     }
 
     /** @test */

--- a/tests/Unit/Http/Controllers/TopicControllerTest.php
+++ b/tests/Unit/Http/Controllers/TopicControllerTest.php
@@ -27,8 +27,6 @@ class TopicControllerTest extends TestCase
 
         $this->get($this->webUrl("/{$topic->slug}"))
             ->assertOk()
-            ->assertSee("Topic: {$topic->name}")
-            ->assertDontSee("Series: {$series->name}")
-            ->assertDontSee("Post: {$post->name}");
+            ->assertSee("-- T:{$topic->id} --");
     }
 }


### PR DESCRIPTION
Also changes `assertSee(...)` tests to use "identity tag" that is stuffed in an HTML comment.  This will allow the view content to be replaced without breaking tests so long as the identity tag is left behind.